### PR TITLE
Refactor withTranslations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["standard", "plugin:react/recommended"],
+  "parser": "babel-eslint",
   "env": {
     "jest": true
   },

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # production
 /build
+dist
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   },
   "dependencies": {
     "intl-messageformat": "^2.2.0",
+    "lodash.foreach": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isnumber": "^3.0.3",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
+    "lodash.kebabcase": "^4.1.1",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.1",
     "lodash.transform": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "jest",
     "test:dev": "jest --watch",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "rollup -c"
   },
   "dependencies": {
     "intl-messageformat": "^2.2.0",
@@ -44,7 +45,9 @@
     "eslint-plugin-standard": "^4.0.0",
     "icu4c-data": "62l",
     "jest": "^23.6.0",
-    "react-dom": "^16.5.2"
+    "react-dom": "^16.5.2",
+    "rollup": "^0.66.6",
+    "rollup-plugin-babel": "^4.0.3"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/test/setup/enzyme.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "intl-messageformat": "^2.2.0",
-    "lodash.foreach": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isnumber": "^3.0.3",
     "lodash.isplainobject": "^4.0.6",
@@ -31,6 +30,7 @@
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge",
+    "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
-  "name": "translated-components",
-  "version": "0.1.0",
+  "name": "@compeon/translated-components",
+  "version": "0.0.1",
   "description": "Applies the component thinking to i18n",
-  "main": "index.js",
+  "main": "dist/translated-components.umd.js",
+  "module": "dist/translated-components.es.js",
   "repository": "git@github.com:COMPEON/translated-components.git",
-  "author": "Lars Greiving <lgreiving@compeon.de>",
+  "authors": [
+    "Lars Greiving <lgreiving@compeon.de>",
+    "Bastian Ahrens <bahrens@compeon.de>"
+  ],
   "license": "MIT",
   "private": false,
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "jest",
     "test:dev": "jest --watch",
@@ -22,7 +29,6 @@
     "lodash.kebabcase": "^4.1.1",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.1",
-    "lodash.transform": "^4.6.0",
     "react": "^16.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compeon/translated-components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Applies the component thinking to i18n",
   "main": "dist/translated-components.umd.js",
   "module": "dist/translated-components.es.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "intl-messageformat": "^2.2.0",
     "lodash.get": "^4.4.2",
     "lodash.isnumber": "^3.0.3",
+    "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
+    "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.1",
     "lodash.transform": "^4.6.0",
     "react": "^16.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compeon/translated-components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Applies the component thinking to i18n",
   "main": "dist/translated-components.umd.js",
   "module": "dist/translated-components.es.js",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
   },
   "dependencies": {
     "intl-messageformat": "^2.2.0",
+    "lodash.get": "^4.4.2",
     "lodash.isnumber": "^3.0.3",
     "lodash.isstring": "^4.0.1",
-    "lodash.kebabcase": "^4.1.1",
+    "lodash.merge": "^4.6.1",
     "lodash.transform": "^4.6.0",
     "react": "^16.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "babel-core": "^7.0.0-bridge",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "jest",
     "test:dev": "jest --watch",
-    "lint": "eslint .",
+    "lint": "eslint src",
     "build": "rollup -c"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,29 @@
+import babel from 'rollup-plugin-babel'
+import pkg from './package.json'
+
+const external = Object.keys(pkg.dependencies)
+
+export default {
+  input: 'src/index.js',
+  output: [
+    {
+      file: 'dist/translated-components.umd.js',
+      name: 'monthpicker',
+      format: 'umd'
+    },
+    {
+      file: 'dist/translated-components.es.js',
+      name: 'monthpicker',
+      format: 'es'
+    }
+  ],
+  plugins: [
+    babel({
+      babelrc: false,
+      exclude: 'node_modules/**',
+      plugins: ['@babel/proposal-class-properties'],
+      presets: [['@babel/env', { modules: false }], '@babel/react']
+    })
+  ],
+  external
+}

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
     const preHeatedTranslations = merge({}, globalTranslations, translations)
 
     return Component => {
-      const displayName = Component.displayName || Component.name || 'Component'
+      const displayName = Component.displayName || Component.name || 'withTranslation(Component)'
 
       return class WrappedComponent extends React.Component {
         static defaultProps = {
@@ -54,7 +54,7 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
           return key
         }
 
-        getTranslateFunc = memoize((locale = defaultLocale, propsTranslations) => {
+        getTranslateFunc = memoize((propsTranslations, locale = defaultLocale) => {
           const formats = {
             ...moneyFormat(locale),
             ...format
@@ -86,9 +86,12 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
 
         render () {
           const { translations, ...props } = this.props
+
           return (
             <TranslationConsumer>
-              {locale => <Component translate={this.getTranslateFunc(locale, translations)} {...props} />}
+              {locale => (
+                <Component translate={this.getTranslateFunc(this.props.translations, locale)} {...props} />
+              )}
             </TranslationConsumer>
           )
         }

--- a/src/index.js
+++ b/src/index.js
@@ -52,9 +52,10 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
         const translateFunc = key => {
           const value = (
             get(propsTranslations[locale], key) ||
-            get(propsTranslations[defaultLocale], key) ||
             get(preHeatedTranslations[locale], key) ||
-            get(preHeatedTranslations[defaultLocale], key)
+            get(propsTranslations[defaultLocale], key) ||
+            get(preHeatedTranslations[defaultLocale], key) ||
+            key
           )
 
           // Return the formatted string for numbers and strings

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ const moneyFormat = locale => ({
 })
 
 const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_LOCALE) => {
-  const withTranslation = ({ translations, format = {} }) => {
+  const withTranslation = ({ translations, format = {} } = {}) => {
     const preHeatedTranslations = merge({}, globalTranslations, translations)
 
     return Component => {

--- a/src/index.js
+++ b/src/index.js
@@ -43,16 +43,16 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
         translations: {}
       }
 
-      getTranslateFunc = (locale = defaultLocale) => {
+      getTranslateFunc = memoize((locale = defaultLocale, propsTranslations) => {
         const formats = {
           ...moneyFormat(locale),
           ...format
         }
 
-        const translateFunc = memoize(key => {
+        const translateFunc = key => {
           const value = (
-            get(this.props.translations[locale], key) ||
-            get(this.props.translations[defaultLocale], key) ||
+            get(propsTranslations[locale], key) ||
+            get(propsTranslations[defaultLocale], key) ||
             get(preHeatedTranslations[locale], key) ||
             get(preHeatedTranslations[defaultLocale], key)
           )
@@ -67,16 +67,16 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
           if (isPlainObject(value)) return subkey => translateFunc([key, subkey])
 
           return value
-        })
+        }
 
         return translateFunc
-      }
+      })
 
       render () {
         const { translations, ...props } = this.props
         return (
           <TranslationConsumer>
-            {locale => <Component translate={this.getTranslateFunc(locale)} {...props} />}
+            {locale => <Component translate={this.getTranslateFunc(locale, translations)} {...props} />}
           </TranslationConsumer>
         )
       }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import merge from 'lodash.merge'
 import isString from 'lodash.isstring'
 import kebabCase from 'lodash.kebabcase'
 import isNumber from 'lodash.isnumber'
-import forEach from 'lodash.forEach'
 import memoize from 'lodash.memoize'
 import isPlainObject from 'lodash.isplainobject'
 import IntlFormat from 'intl-messageformat'
@@ -52,10 +51,10 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
 
         const translateFunc = memoize(key => {
           const value = (
-               get(this.props.translations[locale], key)
-            || get(this.props.translations[defaultLocale], key)
-            || get(preHeatedTranslations[locale], key)
-            || get(preHeatedTranslations[defaultLocale], key)
+            get(this.props.translations[locale], key) ||
+            get(this.props.translations[defaultLocale], key) ||
+            get(preHeatedTranslations[locale], key) ||
+            get(preHeatedTranslations[defaultLocale], key)
           )
 
           // Return the formatted string for numbers and strings

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import get from 'lodash.get'
 import merge from 'lodash.merge'
-import isString from 'lodash.isString'
+import isString from 'lodash.isstring'
+import isNumber from 'lodash.isnumber'
 import memoize from 'lodash.memoize'
-import isPlainObject from 'lodash.isPlainObject'
-import isNumber from 'lodash.isNumber'
+import isPlainObject from 'lodash.isplainobject'
 import IntlFormat from 'intl-messageformat'
 
 const DEFAULT_LOCALE = 'de_DE'

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,14 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Translate components does not touch non-translation props 1`] = `
-<Component
+<WrappedComponent
   notToBeTranslated={99}
+  translations={Object {}}
 >
   <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Eine Schweinshaxe, bitte."
     notToBeTranslated={99}
-    title="Dies ist ein fester Titel"
+    translate={[Function]}
   >
     <img
       width={99}
@@ -23,78 +22,69 @@ exports[`Translate components does not touch non-translation props 1`] = `
       Eine Schweinshaxe, bitte.
     </p>
   </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components formats money correctly for the language 1`] = `
-<Component
+<WrappedComponent
   amount={42.37}
   customTitle="Zipfelklatschr"
+  translations={Object {}}
 >
   <SomeTestComponent
     amount={42.37}
     customTitle="Zipfelklatschr"
-    kebab-label="Du hast € 42,37!"
-    message="Hier wird nie etwas anderes stehen."
-    title="Dies ist ein Zipfelklatschr"
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Dies ist ein Zipfelklatschr
     </h1>
     <h2>
-      Du hast € 42,37!
+      Du hast € 42.37!
     </h2>
     <p>
       Hier wird nie etwas anderes stehen.
     </p>
   </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components formats money correctly for the language 2`] = `
-<Component
+<WrappedComponent
   amount={2500.01}
   customTitle="Toblerone"
+  translations={Object {}}
 >
   <SomeTestComponent
     amount={2500.01}
     customTitle="Toblerone"
-    kebab-label="Du hast CHF 2’500.01!"
-    message="Eine Schweinshaxe, bitte."
-    title="Dies ist ein fester Titel"
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Dies ist ein fester Titel
     </h1>
     <h2>
-      Du hast CHF 2’500.01!
+      Du hast CHF 2,500.01!
     </h2>
     <p>
       Eine Schweinshaxe, bitte.
     </p>
   </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components handles pluralisation 1`] = `
-<Component
+<WrappedComponent
   numBurgers={0}
+  translations={Object {}}
 >
   <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Let's eat no burgers today."
     numBurgers={0}
-    title="Dies ist ein fester Titel"
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Dies ist ein fester Titel
     </h1>
@@ -105,22 +95,19 @@ exports[`Translate components handles pluralisation 1`] = `
       Let's eat no burgers today.
     </p>
   </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components handles pluralisation 2`] = `
-<Component
+<WrappedComponent
   numBurgers={1}
+  translations={Object {}}
 >
   <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Let's eat one burger today."
     numBurgers={1}
-    title="Dies ist ein fester Titel"
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Dies ist ein fester Titel
     </h1>
@@ -131,22 +118,19 @@ exports[`Translate components handles pluralisation 2`] = `
       Let's eat one burger today.
     </p>
   </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components handles pluralisation 3`] = `
-<Component
+<WrappedComponent
   numBurgers={99}
+  translations={Object {}}
 >
   <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Let's eat 99 burgers today."
     numBurgers={99}
-    title="Dies ist ein fester Titel"
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Dies ist ein fester Titel
     </h1>
@@ -157,42 +141,17 @@ exports[`Translate components handles pluralisation 3`] = `
       Let's eat 99 burgers today.
     </p>
   </SomeTestComponent>
-</Component>
-`;
-
-exports[`Translate components passes default \`de_DE\` translated strings to wrapped components 1`] = `
-<Component>
-  <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Eine Schweinshaxe, bitte."
-    title="Dies ist ein fester Titel"
-  >
-    <img
-      width={100}
-    />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
-      Eine Schweinshaxe, bitte.
-    </p>
-  </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;
 
 exports[`Translate components passes translated strings alongside default fallbacks to wrapped components 1`] = `
-<Component>
+<WrappedComponent
+  translations={Object {}}
+>
   <SomeTestComponent
-    kebab-label="Du, du hast."
-    message="Eine Schweinshaxe, bitte."
-    title="Good day, Sir."
+    translate={[Function]}
   >
-    <img
-      width={100}
-    />
+    <img />
     <h1>
       Good day, Sir.
     </h1>
@@ -203,31 +162,5 @@ exports[`Translate components passes translated strings alongside default fallba
       Eine Schweinshaxe, bitte.
     </p>
   </SomeTestComponent>
-</Component>
-`;
-
-exports[`Translate components transforms template params with supplied functions 1`] = `
-<Component
-  interpolated="french"
->
-  <SomeTestComponent
-    interpolated="french"
-    kebab-label="Du, du hast."
-    message="Eine Schweinshaxe, bitte."
-    title="This is going to be really FRENCH!"
-  >
-    <img
-      width={100}
-    />
-    <h1>
-      This is going to be really FRENCH!
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
-      Eine Schweinshaxe, bitte.
-    </p>
-  </SomeTestComponent>
-</Component>
+</WrappedComponent>
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -54,7 +54,7 @@ exports[`Translate components formats money correctly for the language 1`] = `
     translate={[Function]}
   >
     <span>
-      Du hast € 42.37!
+      Du hast € 42,37!
     </span>
   </Component>
 </WrappedComponent>
@@ -70,7 +70,7 @@ exports[`Translate components formats money correctly for the language 2`] = `
     translate={[Function]}
   >
     <span>
-      Du hast CHF 2,500.01!
+      Du hast CHF 2’500.01!
     </span>
   </Component>
 </WrappedComponent>

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,77 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Translate components allows for translation of enum values 1`] = `
+<WrappedComponent
+  translations={Object {}}
+>
+  <Component
+    translate={[Function]}
+  >
+    <span>
+      Überentwurf
+    </span>
+  </Component>
+</WrappedComponent>
+`;
+
 exports[`Translate components does not touch non-translation props 1`] = `
 <WrappedComponent
   notToBeTranslated={99}
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     notToBeTranslated={99}
     translate={[Function]}
   >
-    <img
-      width={99}
-    />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
-      Eine Schweinshaxe, bitte.
-    </p>
-  </SomeTestComponent>
+    <span>
+      99
+    </span>
+  </Component>
+</WrappedComponent>
+`;
+
+exports[`Translate components falls back to the global translations 1`] = `
+<WrappedComponent
+  translations={Object {}}
+>
+  <Component
+    translate={[Function]}
+  >
+    <span>
+      Anfrage
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
 exports[`Translate components formats money correctly for the language 1`] = `
 <WrappedComponent
   amount={42.37}
-  customTitle="Zipfelklatschr"
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     amount={42.37}
-    customTitle="Zipfelklatschr"
     translate={[Function]}
   >
-    <img />
-    <h1>
-      Dies ist ein Zipfelklatschr
-    </h1>
-    <h2>
+    <span>
       Du hast € 42.37!
-    </h2>
-    <p>
-      Hier wird nie etwas anderes stehen.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
 exports[`Translate components formats money correctly for the language 2`] = `
 <WrappedComponent
   amount={2500.01}
-  customTitle="Toblerone"
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     amount={2500.01}
-    customTitle="Toblerone"
     translate={[Function]}
   >
-    <img />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
+    <span>
       Du hast CHF 2,500.01!
-    </h2>
-    <p>
-      Eine Schweinshaxe, bitte.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
@@ -80,21 +81,14 @@ exports[`Translate components handles pluralisation 1`] = `
   numBurgers={0}
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     numBurgers={0}
     translate={[Function]}
   >
-    <img />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
+    <span>
       Let's eat no burgers today.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
@@ -103,21 +97,14 @@ exports[`Translate components handles pluralisation 2`] = `
   numBurgers={1}
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     numBurgers={1}
     translate={[Function]}
   >
-    <img />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
+    <span>
       Let's eat one burger today.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
@@ -126,41 +113,61 @@ exports[`Translate components handles pluralisation 3`] = `
   numBurgers={99}
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     numBurgers={99}
     translate={[Function]}
   >
-    <img />
-    <h1>
-      Dies ist ein fester Titel
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
+    <span>
       Let's eat 99 burgers today.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
 </WrappedComponent>
 `;
 
-exports[`Translate components passes translated strings alongside default fallbacks to wrapped components 1`] = `
+exports[`Translate components translates values using the locale 1`] = `
 <WrappedComponent
   translations={Object {}}
 >
-  <SomeTestComponent
+  <Component
     translate={[Function]}
   >
-    <img />
-    <h1>
+    <span>
       Good day, Sir.
-    </h1>
-    <h2>
-      Du, du hast.
-    </h2>
-    <p>
-      Eine Schweinshaxe, bitte.
-    </p>
-  </SomeTestComponent>
+    </span>
+  </Component>
+</WrappedComponent>
+`;
+
+exports[`Translate components uses a translation from the translation props 1`] = `
+<WrappedComponent
+  translations={
+    Object {
+      "en_GB": Object {
+        "title": "Proper title",
+      },
+    }
+  }
+>
+  <Component
+    translate={[Function]}
+  >
+    <span>
+      Proper title
+    </span>
+  </Component>
+</WrappedComponent>
+`;
+
+exports[`Translate components uses the key when no translation is found 1`] = `
+<WrappedComponent
+  translations={Object {}}
+>
+  <Component
+    translate={[Function]}
+  >
+    <span>
+      blaBlubb
+    </span>
+  </Component>
 </WrappedComponent>
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -158,7 +158,7 @@ exports[`Translate components uses a translation from the translation props 1`] 
 </WrappedComponent>
 `;
 
-exports[`Translate components uses the key when no translation is found 1`] = `
+exports[`Translate components uses the key when no translation is found and warns about it 1`] = `
 <WrappedComponent
   translations={Object {}}
 >

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,33 +2,31 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { TranslationProvider, withTranslation } from '../src'
 
-const SomeTestComponent = ({
-  notToBeTranslated = 100,
-  title = 'a default title',
-  'kebab-label': kebabLabel = 'a default kebab label',
-  message = 'a default message'
-}) => (
+const SomeTestComponent = ({ translate, notToBeTranslated }) => (
   <React.Fragment>
     <img width={notToBeTranslated} />
-    <h1>{title}</h1>
-    <h2>{kebabLabel}</h2>
-    <p>{message}</p>
+    <h1>{translate('title')}</h1>
+    <h2>{translate('kebabLabel')}</h2>
+    <p>{translate('message')}</p>
   </React.Fragment>
 )
 
 const translations = {
   de_DE: {
     title: 'Dies ist ein fester Titel',
-    'kebab-label': 'Du, du hast.',
+    kebabLabel: 'Du, du hast.',
     message: 'Eine Schweinshaxe, bitte.'
   },
   de_AT: {
     title: 'Dies ist ein {customTitle}',
-    'kebab-label': 'Du hast {amount, number, money}!',
+    x: {
+      title: '123'
+    },
+    kebabLabel: 'Du hast {amount, number, money}!',
     message: 'Hier wird nie etwas anderes stehen.'
   },
   de_CH: {
-    'kebab-label': 'Du hast {amount, number, money}!'
+    kebabLabel: 'Du hast {amount, number, money}!'
   },
   en_GB: {
     title: 'Good day, Sir.'
@@ -41,12 +39,8 @@ const translations = {
   }
 }
 
-const params = {
-  interpolated: ({ interpolated = '' }) => `really ${interpolated.toUpperCase()}!`
-}
-
 describe('Translate components', () => {
-  const TranslatedTestComponent = withTranslation({ translations, params })(SomeTestComponent)
+  const TranslatedTestComponent = withTranslation({ translations })(SomeTestComponent)
 
   const subject = ({ locale, ...rest }) => (
     mount(
@@ -55,12 +49,9 @@ describe('Translate components', () => {
       </TranslationProvider>
     )
   )
+
   it('does not touch non-translation props', () => {
     expect(subject({ notToBeTranslated: 99 })).toMatchSnapshot()
-  })
-
-  it('passes default `de_DE` translated strings to wrapped components', () => {
-    expect(subject({})).toMatchSnapshot()
   })
 
   it('passes translated strings alongside default fallbacks to wrapped components', () => {
@@ -76,9 +67,5 @@ describe('Translate components', () => {
     expect(subject({ locale: 'en_US', numBurgers: 0 })).toMatchSnapshot()
     expect(subject({ locale: 'en_US', numBurgers: 1 })).toMatchSnapshot()
     expect(subject({ locale: 'en_US', numBurgers: 99 })).toMatchSnapshot()
-  })
-
-  it('transforms template params with supplied functions', () => {
-    expect(subject({ locale: 'fr_FR', interpolated: 'french' })).toMatchSnapshot()
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { TranslationProvider, withTranslation } from '../src'
 
+/* eslint-disable-next-line */
 const SomeTestComponent = ({ translate, notToBeTranslated }) => (
   <React.Fragment>
     <img width={notToBeTranslated} />

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,9 +77,14 @@ describe('Translate components', () => {
     expect(subject(Component, { locale: 'de_DE' })).toMatchSnapshot()
   })
 
-  it('uses the key when no translation is found', () => {
+  it('uses the key when no translation is found and warns about it', () => {
     const Component = ({ translate }) => <span>{translate('blaBlubb')}</span>
+    const warn = jest.spyOn(global.console, 'warn')
+
     expect(subject(Component, { locale: 'de_DE' })).toMatchSnapshot()
+    expect(warn).toHaveBeenCalledWith(
+      'Component: Key "blaBlubb" was not found. Falling back to the key as translation'
+    )
   })
 
   it('allows for translation of enum values', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -622,6 +622,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
 "@types/node@*":
   version "10.11.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
@@ -1765,6 +1769,10 @@ esrecurse@^4.1.0:
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -4045,6 +4053,27 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+rollup-plugin-babel@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.0.3.tgz#8282b0e22233160d679e9c7631342e848422fb02"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    rollup-pluginutils "^2.3.0"
+
+rollup-pluginutils@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
+
+rollup@^0.66.6:
+  version "0.66.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.6.tgz#ce7d6185beb7acea644ce220c25e71ae03275482"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,16 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.1.3.tgz#2103ec9c42d9bdad9190a6ad5ff2d456fd7b8673"
+  dependencies:
+    "@babel/types" "^7.1.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -195,6 +205,10 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.1.2":
   version "7.1.2"
@@ -564,6 +578,20 @@
     "@babel/parser" "^7.1.2"
     "@babel/types" "^7.1.2"
 
+"@babel/traverse@^7.0.0":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.4.tgz#f4f83b93d649b4b2c91121a9087fa2fa949ec2b4"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.1.3"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.0.0"
+    "@babel/parser" "^7.1.3"
+    "@babel/types" "^7.1.3"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.10"
+
 "@babel/traverse@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.0.tgz#503ec6669387efd182c3888c4eec07bcc45d91b2"
@@ -581,6 +609,14 @@
 "@babel/types@^7.0.0", "@babel/types@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.2.tgz#183e7952cf6691628afdc2e2b90d03240bac80c0"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.1.3.tgz#3a767004567060c2f40fca49a304712c525ee37d"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -835,6 +871,17 @@ babel-core@^6.0.0, babel-core@^6.26.0:
 babel-core@^7.0.0-bridge:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -1622,6 +1669,13 @@ eslint-plugin-react@^7.11.1:
 eslint-plugin-standard@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0:
   version "4.0.0"
@@ -3025,10 +3079,6 @@ lodash.escape@^4.0.1:
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
-
-lodash.foreach@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
 lodash.get@^4.4.2:
   version "4.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,17 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -240,6 +251,12 @@
 "@babel/plugin-syntax-async-generators@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -3009,6 +3026,10 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -3021,9 +3042,9 @@ lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
-lodash.kebabcase@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+lodash.merge@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3026,6 +3026,10 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -3045,6 +3049,10 @@ lodash.isplainobject@^4.0.6:
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
 lodash.memoize@^4.1.2:
   version "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,10 +3124,6 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash.transform@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.transform/-/lodash.transform-4.6.0.tgz#12306422f63324aed8483d3f38332b5f670547a0"
-
 lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,9 +3038,17 @@ lodash.isnumber@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
 lodash.merge@^4.6.1:
   version "4.6.1"


### PR DESCRIPTION
~STILL WIP~

When trying out this implementation in one of our apps I had a few problems/questions, both practical and conceptual:

- How would you go about using global translations? For things like model attributes etc.
- What about enums? The lib as it is right now will break if a key in your translation object has an object literal as a value. So all keys have to be on the top-level; which is probably fine for component level translations like a title, but is annoying for the global translations and enums.
- I personally don't like polluting the props with all the translations, as it possibly leads to name clashes, slows down react and again isn't really practicable with global translations
- Performance:
  - On every re-render there are at least 5 (!) `transform`s, running on the whole translation object, building a `IntlFormat`out of every translation, which is not necessary at all, because the child component will probably only use 5 of those values.

So resulting from those points I made a few decisions/changes:
- There is a new export called `createWithTranslation`, which allows your app to have your own version of `withTranslation` preloaded with your global translations and your default locale. If you don't want to use that, there is still an export 
 `withTranslation` with no global translations and german as a default locale.
- This means every `withTranslation` you use in your app already knows about the global translations and can merge them with the local translations/props. 

	Merging happens in the follwing order, from lowest to highest priority:
	  - globalTranslations of the specified locale
	  - translations passed to `withTranslation` of the defaultLocale,
	  - translations passed to `withTranslation` of the current locale,
	  - `translation` prop passed to the WrappedComponent
	
	This allows for
	 1. Using global translations, without further specifying anthing
	 2. Specifying component level translations at build time
	 3. Changing component level translations at run time (through props)




- Translations are now 'passed' down as one `translate` function, which knows about the current and default locale, all the translations and transforms the selected translations (and only that one) to an `IntlFormat` object.
  - This results in easier handling of enums, as the translate function returns another function, if the given key results in an object as a translation
  - so you could create a `translateEnum` function by calling `translate('some.object.key')`
