### PR TITLE
switch travis build architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - '10'


### PR DESCRIPTION
context: Trevis will drop support for `sudo: false`
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration