### PR TITLE
Add prop for controlling the translation scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const defaultOptions = {
 }
 
 const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_LOCALE) => {
-  const withTranslation = ({ translations, format = {} } = {}) => {
+  const withTranslation = ({ translations, format = {}, scope = null } = {}) => {
     const preHeatedTranslations = merge({}, globalTranslations, translations)
 
     return Component => {
@@ -65,17 +65,21 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
           }
 
           const translateFunc = (key, translateOptions) => {
+            const scopedKey = `${scope}.${key}`
+
+            const lookupKey = scope ? scopedKey : key
+
             const options = {
               ...defaultOptions,
               ...translateOptions
             }
 
             const value = (
-              get(propsTranslations[locale], key) ||
-              get(preHeatedTranslations[locale], key) ||
-              get(propsTranslations[defaultLocale], key) ||
-              get(preHeatedTranslations[defaultLocale], key) ||
-              (options.fallbackToKey ? this.warnAboutMissingTranslation(key) : null)
+              get(propsTranslations[locale], lookupKey) ||
+              get(preHeatedTranslations[locale], lookupKey) ||
+              get(propsTranslations[defaultLocale], lookupKey) ||
+              get(preHeatedTranslations[defaultLocale], lookupKey) ||
+              (options.fallbackToKey ? this.warnAboutMissingTranslation(lookupKey) : null)
             )
 
             // Return the formatted string for numbers and strings

--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,7 @@ const createWithTranslation = (globalTranslations = {}, defaultLocale = DEFAULT_
           }
 
           const translateFunc = (key, translateOptions) => {
-            const scopedKey = `${scope}.${key}`
-
-            const lookupKey = scope ? scopedKey : key
+            const lookupKey = scope ? `${scope}.${key}` : key
 
             const options = {
               ...defaultOptions,

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -28,6 +28,20 @@ exports[`Translate components allows for overwriting prop values by passing opti
 </WrappedComponent>
 `;
 
+exports[`Translate components allows for setting a scope in withTranslation 1`] = `
+<WrappedComponent
+  translations={Object {}}
+>
+  <Component
+    translate={[Function]}
+  >
+    <span>
+      karl
+    </span>
+  </Component>
+</WrappedComponent>
+`;
+
 exports[`Translate components allows for translation of enum values 1`] = `
 <WrappedComponent
   translations={Object {}}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,14 @@ const translations = {
   de_DE: {
     title: 'Dies ist ein fester Titel',
     kebabLabel: 'Du, du hast.',
-    message: 'Eine Schweinshaxe, bitte.'
+    message: 'Eine Schweinshaxe, bitte.',
+    a: {
+      deeply: {
+        nested: {
+          maschmüller: 'karl'
+        }
+      }
+    }
   },
   de_AT: {
     title: 'Dies ist ein {customTitle}',
@@ -44,8 +51,8 @@ const translations = {
 describe('Translate components', () => {
   const withTranslation = createWithTranslation(globalTranslations)
 
-  const subject = (Component, { locale, ...rest }) => {
-    const WrappedComponent = withTranslation({ translations })(Component)
+  const subject = (Component, { locale, scope, ...rest }) => {
+    const WrappedComponent = withTranslation({ translations, scope })(Component)
 
     return mount(
       <TranslationProvider value={locale}>
@@ -121,5 +128,12 @@ describe('Translate components', () => {
     const Component = ({ translate }) => <span>{translate('carsten.kurt.maschmüller', { fallbackToKey: false })}</span>
 
     expect(subject(Component, { locale: 'de_DE' })).toMatchSnapshot()
+  })
+
+  it('allows for setting a scope in withTranslation', () => {
+    const Component = ({ translate }) => <span>{translate('maschmüller')}</span>
+
+    expect(subject(Component, { locale: 'de_DE', scope: 'a.deeply.nested' })).toMatchSnapshot()
+
   })
 })


### PR DESCRIPTION
Most of the time a component stays in a certain scope for the translations. This prop allows for setting the translation scope for a component, to avoid duplicating the path for every translation or having to preload `translate` yourself.