### PR TITLE
Add prepublish hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jest",
     "test:dev": "jest --watch",
     "lint": "eslint src",
+    "prepublishOnly": "yarn test && yarn build",
     "build": "rollup -c"
   },
   "dependencies": {


### PR DESCRIPTION
With this change, we avoid the risk of publishing empty or old packages.