### PR TITLE
Remove package intl-pluralrules

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.3",
-    "@formatjs/intl-pluralrules": "^1.4.2",
     "intl-messageformat": "^7.8.0",
     "lodash.get": "^4.4.2",
     "lodash.isnumber": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,13 +1096,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@formatjs/intl-pluralrules@^1.4.2":
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz#c363c833c0ccde11eb508de4c09d3eaa232e819a"
-  integrity sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==
-  dependencies:
-    "@formatjs/intl-utils" "^2.3.0"
-
 "@formatjs/intl-unified-numberformat@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.2.0.tgz#5197987e61ba0972889105e525f1cbe6d91cf46f"
@@ -1114,11 +1107,6 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz#ba6e12fe64ff7fd160be392007c47d24b7ae5c75"
   integrity sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w==
-
-"@formatjs/intl-utils@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz#2dc8c57044de0340eb53a7ba602e59abf80dc799"
-  integrity sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
This removes the package `@formatjs/intl-pluralrules` from translated-components, due to this changelog-entry:

```
## [0.2.0] - 2021-08-26
### BREAKING CHANGES
- Removed `@formatjs/intl-pluralrules` polyfill.
  Apps now need to provide the polyfills required for `intl-messageformat` themselves.
  Check https://formatjs.io/docs/intl-messageformat for help.
```

