### PR TITLE
Fix rollup warning messages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,41 @@
 import { babel } from '@rollup/plugin-babel'
 import pkg from './package.json'
 
-const external = Object.keys(pkg.dependencies)
+const external = [
+  ...Object.keys(pkg.dependencies),
+  '@babel/runtime/helpers/extends',
+  '@babel/runtime/helpers/objectWithoutProperties',
+  '@babel/runtime/helpers/classCallCheck',
+  '@babel/runtime/helpers/createClass',
+  '@babel/runtime/helpers/assertThisInitialized',
+  '@babel/runtime/helpers/inherits',
+  '@babel/runtime/helpers/possibleConstructorReturn',
+  '@babel/runtime/helpers/getPrototypeOf',
+  '@babel/runtime/helpers/defineProperty',
+  'prop-types'
+]
+
+const globals = {
+  '@babel/runtime/helpers/extends': '_extends',
+  '@babel/runtime/helpers/objectWithoutProperties': '_objectWithoutProperties',
+  '@babel/runtime/helpers/classCallCheck': '_classCallCheck',
+  '@babel/runtime/helpers/createClass': '_createClass',
+  '@babel/runtime/helpers/assertThisInitialized' : '_assertThisInitialized',
+  '@babel/runtime/helpers/inherits': '_inherits',
+  '@babel/runtime/helpers/possibleConstructorReturn': '_possibleConstructorReturn',
+  '@babel/runtime/helpers/getPrototypeOf': '_getPrototypeOf',
+  '@babel/runtime/helpers/defineProperty': '_defineProperty',
+  react : 'React',
+  'prop-types' : 'propTypes',
+  'lodash.get': 'get',
+  'lodash.merge' : 'merge',
+  'lodash.isstring' : 'isString',
+  'lodash.kebabcase' : 'kebabCase',
+  'lodash.isnumber' : 'isNumber',
+  'lodash.memoize' : 'memoize',
+  'lodash.isplainobject' : 'isPlainObject',
+  'intl-messageformat' : 'IntlFormat',
+}
 
 export default {
   input: 'src/index.js',
@@ -9,12 +43,14 @@ export default {
     {
       file: 'dist/translated-components.umd.js',
       name: 'translated-components',
-      format: 'umd'
+      format: 'umd',
+      globals
     },
     {
       file: 'dist/translated-components.es.js',
       name: 'translated-components',
-      format: 'es'
+      format: 'es',
+      globals
     }
   ],
   plugins: [


### PR DESCRIPTION
Fixes the warnings when using `yarn build`

Before:
![Bildschirmfoto 2022-03-15 um 12 09 04](https://user-images.githubusercontent.com/53489780/158365249-668696cb-bfd4-4600-a8b6-8461ffde6d52.png)

After:
![Bildschirmfoto 2022-03-15 um 12 08 38](https://user-images.githubusercontent.com/53489780/158365268-e07c3ffd-4b94-4c11-bb21-616193296612.png)
